### PR TITLE
fix: LICENSE link

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ NyaDB version 4 transitions from a single-file database structure (`database.jso
 
 ## License
 
-This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.
+This project is licensed under the MIT License. See the [LICENSE](LICENSE.md) file for details.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decaded/nyadb",
-  "version": "3.0.0",
+  "version": "4.0.1",
   "description": "Simple JSON \"database\" for NodeJS.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
[LICENSE](https://github.com/Decaded/NyaDB/blob/master/LICENSE.md) file was missing extension, so it couldn't be accessed via hyperlink in [README](https://github.com/Decaded/NyaDB/blob/master/README.md) file